### PR TITLE
lh/opt

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,6 @@ using DocumenterVitepress
 DocMeta.setdocmeta!(OffsetTables, :DocTestSetup, :(using OffsetTables); recursive=true)
 
 makedocs(;
-    modules=[OffsetTables],
     authors="Lilith Orion Hafner <lilithhafner@gmail.com> and contributors",
     repo=Remotes.GitHub("LilithHafner", "OffsetTables.jl"),
     sitename="OffsetTables.jl",

--- a/src/OffsetTables.jl
+++ b/src/OffsetTables.jl
@@ -49,26 +49,28 @@ end
 
 OffsetTable(weights::AbstractVector{<:Real}; normalize=true) = OffsetTable{UInt, Int}(weights; normalize)
 OffsetTable{T}(weights::AbstractVector{<:Real}; normalize=true) where T <: Unsigned = OffsetTable{T, Int}(weights; normalize)
-# function OffsetTable{T, I}(weights::AbstractVector{<:Real}; normalize=true) where {T <: Unsigned, I <: Integer}
-#     Base.require_one_based_indexing(weights)
-#     isempty(weights) && throw(ArgumentError("weights must be non-empty"))
-#     if normalize
-#         _offset_table(T, I, normalize_to_uint(T, weights))
-#     else
-#         _offset_table(T, I, weights)
-#     end
-# end
-
-struct WithZeros{T, P <: AbstractVector{T}} <: AbstractVector{T}
-    parent::P
-    length::Int
+function OffsetTable{T, I}(weights; normalize=true) where {T <: Unsigned, I <: Integer}
+    # function _OffsetTable(::Type{T}, ::Type{I}, weights; normalize=true) where {T <: Unsigned, I <: Integer}
+    Base.require_one_based_indexing(weights)
+    if normalize
+        (is_constant, sm) = checked_sum(weights)
+        if is_constant
+            _constant_offset_table(T, I, sm)
+        elseif sm == 0 # pre-normalized
+            _offset_table(T, I, weights)
+        else
+            # norm = normalize_to_uint_lazy_frac_div(T, weights, sm)
+            norm = normalize_to_uint_frac_div(T, weights, sm)
+            _offset_table(T, I, norm)
+        end
+    else
+        _offset_table(T, I, weights)
+    end
 end
-Base.size(wz::WithZeros) = (wz.length,)
-Base.getindex(wz::WithZeros{T}, i) where T = i <= length(wz.parent) ? wz.parent[i] : zero(T)
 
 function _constant_offset_table(::Type{T}, ::Type{I}, index) where {I, T}
     bitshift = Base.top_set_bit(index - 1)
-    len = 1 << bitshift#next_or_eq_power_of_two(length(weights))
+    len = 1 << bitshift
     points_per_cell = one(T) << (8*sizeof(T) - bitshift)#typemax(T)+1 / len
 
     probability_offset = Memory{Tuple{T, I}}(undef, len)
@@ -306,7 +308,7 @@ function Base.hash(ot::OffsetTable, h::UInt)
     hash(MapVector{typeof(norm(po1)), typeof(norm), typeof(ot.probability_offset)}(ot.probability_offset, norm), h)
 end
 
-## Mediocre float handling
+## Normalization
 
 maybe_unsigned(x) = x # this is necessary to avoid calling unsigned on BigInt, Flaot64, etc.
 maybe_unsigned(x::Base.BitSigned) = unsigned(x)
@@ -363,154 +365,10 @@ function normalize_to_uint(::Type{T}, v::AbstractVector{<:Real}) where {T <: Uns
     res
 end
 
-function normalize_to_uint_widen(::Type{T}, v::AbstractVector{<:Integer}) where {T <: Unsigned}
-    T2 = widen(T)
-    den = sum(T2, v)
-    num = T2(typemax(T)) + one(T2)
-    res = Vector{T}(undef, length(v))
-    for (i,x) in enumerate(v)
-        chosen = Base.udiv_int(num*x, den)
-        num -= chosen
-        den -= x
-        res[i] = chosen
-    end
-    res
-end
-
-function normalize_to_uint_dual_overflow(::Type{T}, v::AbstractVector{<:Integer}) where {T <: Unsigned}
-    sm = sum(T, v)
-    q, r = divrem(typemax(T), sm)
-    if r == sm-true
-        q += true
-        r = zero(r)
-    else
-        r += true
-    end
-    # q, r = divrem(typemax(T)+1, sm)
-
-    error = zero(T)
-    res = Vector{T}(undef, length(v))
-    for (i,x) in enumerate(v)
-        tx = T(x)
-        # @show q, r, tx, r*tx
-        error += r*tx # TODO: check overflow
-        carry, error = divrem(error, sm)
-        res[i] = q*tx + carry
-    end
-    res
-end
-
-function mul_hi_lo(x::T, y::T) where T <: Unsigned
-    hbits = 4sizeof(T)
-    lo_mask = T(1) << hbits - 1
-    lo_x = x & lo_mask
-    lo_y = y & lo_mask
-    hi_x = x >> hbits
-    hi_y = y >> hbits
-
-    lo = lo_x * lo_y
-    hi = hi_x * hi_y
-
-    mid = lo_x * hi_y
-    lo += mid << hbits
-    hi += mid >> hbits
-
-    mid = hi_x * lo_y
-    lo += mid << hbits
-    hi += mid >> hbits
-
-    hi, lo
-end
-
-function mul_hi_lo_2(x::T, y::T) where T <: Unsigned
-    hbits = 4sizeof(T)
-    lo_mask = T(1) << hbits - 1
-    lo_x = x & lo_mask
-    lo_y = y & lo_mask
-    hi_x = x >> hbits
-    hi_y = y >> hbits
-
-    hi = hi_x * hi_y
-
-    mid = lo_x * hi_y
-    hi += mid >> hbits
-
-    mid = hi_x * lo_y
-    hi += mid >> hbits
-
-    hi, x*y
-end
-
-function mul_hi_lo_3(x::T, y::T) where T <: Unsigned
-    xy = widemul(x, y)
-    (x >> 8sizeof(T)) % T, x % T
-end
-
-function normalize_to_uint_dual(::Type{T}, v::AbstractVector{<:Integer}) where {T <: Unsigned}
-    sm = sum(T, v)
-    q, r = divrem(typemax(T), sm)
-    if r == sm-true
-        q += true
-        r = zero(r)
-    else
-        r += true
-    end
-    # q, r = divrem(typemax(T)+1, sm)
-
-    error = zero(T)
-    res = Vector{T}(undef, length(v))
-    for (i,x) in enumerate(v)
-        tx = T(x)
-        # @show q, r, tx, r*tx
-        hi, lo = mul_hi_lo_3(r, tx)
-        error += r*tx # TODO: check overflow
-        carry, error = divrem(error, sm)
-        res[i] = q*tx + carry
-    end
-    res
-end
-
-
 function frac_div(x::T, y::T) where T <: Unsigned
     # @assert x < y
     # @assert y != 0
     div(widen(x) << 8sizeof(T), y) % T
-end
-frac_div(x, y) = frac_div(promote(x, y)...)
-function frac_div_2(x::T, y::T) where T <: Unsigned
-    # @assert x < y
-    # @assert y != 0
-    Base.udiv_int(promote(widen(x) << 8sizeof(T), y)...) % T
-end
-
-function normalize_to_uint_frac_div(::Type{T}, v, sm=sum(T,v)) where {T <: Unsigned}
-    if sm isa AbstractFloat
-        shift = 8sizeof(T)-exponent(sm + sqrt(eps(sm)))-1
-        v2 = res = [floor(T, ldexp(x, shift)) for x in v]
-        onz = get_only_nonzero(v2)
-        onz != -2 && return res
-        sm2 = sum(res)
-    else
-        v2 = v
-        res = Vector{T}(undef, length(v))
-        sm2 = sm
-    end
-
-    sm3 = zero(T)
-
-    for (i,x) in enumerate(v2)
-        val = frac_div(T(x), T(sm2))
-        sm3 += val
-        res[i] = val
-    end
-
-    sm3 == 0 && return res
-
-    for i in sm3:typemax(sm3)
-        res[typemax(sm3)-i+1] += true
-    end
-
-    res
 end
 
 ####
@@ -563,107 +421,47 @@ function checked_sum(weights)
 end
 
 # Second phase
-function normalize_to_uint_lazy_frac_div(::Type{T}, weights, sm) where T <: Unsigned
-    sm2 = zero(T)
-    for x in weights
-        sm2 += frac_div(T(x), sm)
-    end
-    sm2_copy = sm2 # lolz https://github.com/JuliaLang/julia/issues/15276
 
-    bonus = typemax(sm2)-sm2+1
-    (frac_div(T(x), sm) + (i <= bonus) for (i,x) in enumerate(weights))
-end
+# Slower than allocating:
+# function normalize_to_uint_lazy_frac_div(::Type{T}, weights, sm) where T <: Unsigned
+#     sm2 = zero(T)
+#     for x in weights
+#         sm2 += frac_div(T(x), sm)
+#     end
+#     sm2_copy = sm2 # lolz https://github.com/JuliaLang/julia/issues/15276
 
-# Coordinator
-function OffsetTable{T, I}(weights; normalize=true) where {T <: Unsigned, I <: Integer}
-# function _OffsetTable(::Type{T}, ::Type{I}, weights; normalize=true) where {T <: Unsigned, I <: Integer}
-    Base.require_one_based_indexing(weights)
-    if normalize
-        (is_constant, sm) = checked_sum(weights)
-        if is_constant
-            _constant_offset_table(T, I, sm)
-        elseif sm == 0 # pre-normalized
-            _offset_table(T, I, weights)
-        else
-            # norm = normalize_to_uint_lazy_frac_div(T, weights, sm)
-            norm = normalize_to_uint_frac_div(T, weights, sm)
-            _offset_table(T, I, norm)
-        end
+#     bonus = typemax(sm2)-sm2+1
+#     (frac_div(T(x), sm) + (i <= bonus) for (i,x) in enumerate(weights))
+# end
+
+function normalize_to_uint_frac_div(::Type{T}, v, sm=sum(T,v)) where {T <: Unsigned}
+    if sm isa AbstractFloat
+        shift = 8sizeof(T)-exponent(sm + sqrt(eps(sm)))-1
+        v2 = res = [floor(T, ldexp(x, shift)) for x in v]
+        onz = get_only_nonzero(v2)
+        onz != -2 && return res
+        sm2 = sum(res)
     else
-        # onz = get_only_nonzero(weights)
-        # if onz != -2
-            # _constant_offset_table(T, I, onz)
-        # else
-            _offset_table(T, I, weights)
-        # end
+        v2 = v
+        res = Vector{T}(undef, length(v))
+        sm2 = sm
     end
+
+    sm3 = zero(T)
+
+    for (i,x) in enumerate(v2)
+        val = frac_div(T(x), T(sm2))
+        sm3 += val
+        res[i] = val
+    end
+
+    sm3 == 0 && return res
+
+    for i in sm3:typemax(sm3)
+        res[typemax(sm3)-i+1] += true
+    end
+
+    res
 end
-
-## Strict (fragile) & efficient float handling
-
-# struct RescaleView{T, P} <: AbstractVector{T}
-#     parent::P
-# end
-# Base.getindex(rv::RescaleView{T}, i) where T = T(ldexp(rv.parent[i], 8*sizeof(T)))
-# Base.size(rv::RescaleView) = size(rv.parent)
-# OffsetTable{T, I}(weights::AbstractVector{<:Real}) where {T, I} = _offset_table(I, RescaleView{T, typeof(weights)}(weights))
-
-## Better float handling (wip)
-
-# function offset_table_float(::Type{T}, ::Type{I}, weights::AbstractVector{<:Real}) where {T <: Unsigned, I <: Integer}
-#     Base.require_one_based_indexing(weights)
-
-#     bitshift = Base.top_set_bit(length(weights) - 1)
-#     len = 1 << bitshift#next_or_eq_power_of_two(length(weights))
-#     points_per_cell = one(T) << (8*sizeof(T) - bitshift)#typemax(T)+1 / len
-
-#     thirsty_i = surplus_i = current_i = firstindex(weights)
-#     current_desired = weights[current_i]
-
-#     exp = exponent(sum(weights))
-#     real_to_uint(x) = floor(T, ldexp(x, 8sizeof(T)-exp))
-#     # sum(real_to_uint, weights) could be as low as 0 if weights = fill(1, 2^33) and T=UInt32, though in that case we can assign every bin either 0 or 1 point at will
-#     # it could be equal to typemax(T)+1 if weights = [1] or there is otherwise no rounding down.
-#     sm = sum(widen ∘ real_to_uint, weights)
-
-
-
-#     probability_offset = Memory{Tuple{T, I}}(undef, len)
-
-
-#     while true
-#         # @show current_i, current_desired, points_per_cell
-#         if current_desired <= points_per_cell # Surplus
-#             excess = points_per_cell - current_desired                     # Assign this many extra points
-#             thirsty_i = findnext(>(points_per_cell), weights, thirsty_i+1) # Which is the next available thirsty cell
-#             thirsty_i === nothing && break                                 # If there is no thirsty cell, handle below
-#             probability_offset[current_i] = (excess, thirsty_i-current_i)  # To the targeted cell
-#             current_i = thirsty_i                                          # Now we have to make sure that thristy cell gets exactly what it wants and no more
-#             current_desired = weights[current_i] - excess                  # It wants what it wants nad hasn't already been transferred
-#         else                                  # Thirsty (strictly)
-#             surplus_i = findnext(<=(points_per_cell), weights, surplus_i+1) # Find the next surplus cell
-#             surplus_i === nothing && throw(ArgumentError("sum(weights) is too high")) # Lacking points, so unnable to reach the desired weight
-#             excess = weights[surplus_i] - points_per_cell                   # Assign this many extra points
-#             probability_offset[surplus_i] = (excess, current_i-surplus_i)   # From the cell with surplus to this cell
-#             current_desired -= excess                                       # We now don't want as many points (and may even no longer be thristy)
-#         end
-#     end
-#     if current_desired < points_per_cell # Surplus points, so exceed the desired weight
-#         throw(ArgumentError("sum(weights) is too low"))
-#     end
-#     probability_offset[current_i] = (0, 0)
-#     # Just right. There are no thristy cells left and no current surplus. All that's left
-#     # are future surplus cells, all of which should be a surplus of exactly 0.
-#     while true
-#         surplus_i = findnext(<=(points_per_cell), weights, surplus_i+1) # Find the next surplus cell
-#         surplus_i === nothing && break
-#         weights[surplus_i] == points_per_cell || throw(ArgumentError("sum(weights) is too low"))
-#         probability_offset[surplus_i] = (0, 0)
-#     end
-
-#     OffsetTable(probability_offset)
-# end
-
-
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,8 @@ using RegressionTests
         @test rand(OffsetTable([1e-70, 1])) == 2
         @test rand(OffsetTable([0, 1]), 3)::Vector{Int} == [2,2,2]
         @test rand(OffsetTable{UInt, Int8}([0, 1]), 3)::Vector{Int8} == [2,2,2]
+
+        @test rand(OffsetTavle([typemax(Int)-10, 5, 5, 5])) == 1 # wrong answer due to overflow on normalizations leading to throw on construction
     end
 
     @testset "Invalid weight error messages" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,13 +21,12 @@ using RegressionTests
         @test rand(OffsetTable([1e-70, 1])) == 2
         @test rand(OffsetTable([0, 1]), 3)::Vector{Int} == [2,2,2]
         @test rand(OffsetTable{UInt, Int8}([0, 1]), 3)::Vector{Int8} == [2,2,2]
-
-        @test rand(OffsetTable([typemax(Int)-10, 5, 5, 5])) == 1 # wrong answer due to overflow on normalizations leading to throw on construction
+        @test rand(OffsetTable([typemax(Int)-10, 5, 5, 5])) == 1
     end
 
     @testset "Invalid weight error messages" begin
-        @test_throws ArgumentError("found negative weight -1 at index 2") OffsetTable([1, -1])
-        @test_throws ArgumentError("found negative weight -1 at index 3") OffsetTable([1, 1, -1])
+        @test_throws ArgumentError("found negative weight -1") OffsetTable([1, -1])
+        @test_throws ArgumentError("found negative weight -1") OffsetTable([1, 1, -1])
         @test_throws ArgumentError("all weights are zero") OffsetTable([0, 0])
         @test_throws ArgumentError("all weights are zero") OffsetTable([0])
         @test_throws ArgumentError("all weights are zero") OffsetTable(UInt[0, 0])
@@ -51,6 +50,7 @@ using RegressionTests
         for i in 1:100
             p = rand(i)
             ot = OffsetTable(p)
+            @test maximum(abs, OffsetTables.probabilities(ot) ./ (big(typemax(UInt))+1) .- p ./ sum(big, p)) ≤ .5^64
             @test OffsetTables.probabilities(float, ot) ≈  p ./ sum(p)
             @test OffsetTable(OffsetTables.probabilities(ot)) == ot
             # @test OffsetTable(OffsetTables.probabilities(float, ot)) == ot
@@ -62,6 +62,7 @@ using RegressionTests
                 p2[end] = typemax(UInt) - sum(p2[1:end-1]) + 1
             end
             ot2 = OffsetTable(p2)
+            @test maximum(abs, OffsetTables.probabilities(ot2) ./ (big(typemax(UInt))+1) .- p2 ./ sum(big, p2)) ≤ .5^64
             @test OffsetTables.probabilities(ot2) == p2
             @test OffsetTables.probabilities(float, ot2) ≈  p ./ sum(p)
             # @test OffsetTable(OffsetTables.probabilities(float, ot2)) == ot2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,8 @@ using RegressionTests
 
 @testset "OffsetTables.jl" begin
     @testset "Code quality (Aqua.jl)" begin
-        Aqua.test_all(OffsetTables, deps_compat=false)
-        Aqua.test_deps_compat(OffsetTables, check_extras=false)
+        # Aqua.test_all(OffsetTables, deps_compat=false)
+        # Aqua.test_deps_compat(OffsetTables, check_extras=false)
     end
 
     @testset "Basic" begin
@@ -22,7 +22,7 @@ using RegressionTests
         @test rand(OffsetTable([0, 1]), 3)::Vector{Int} == [2,2,2]
         @test rand(OffsetTable{UInt, Int8}([0, 1]), 3)::Vector{Int8} == [2,2,2]
 
-        @test rand(OffsetTavle([typemax(Int)-10, 5, 5, 5])) == 1 # wrong answer due to overflow on normalizations leading to throw on construction
+        @test rand(OffsetTable([typemax(Int)-10, 5, 5, 5])) == 1 # wrong answer due to overflow on normalizations leading to throw on construction
     end
 
     @testset "Invalid weight error messages" begin
@@ -133,6 +133,6 @@ using RegressionTests
     end
 
     @testset "RegressionTests" begin
-        RegressionTests.test(skip_unsupported_platforms=true)
+        # RegressionTests.test(skip_unsupported_platforms=true)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,8 @@ using RegressionTests
 
 @testset "OffsetTables.jl" begin
     @testset "Code quality (Aqua.jl)" begin
-        # Aqua.test_all(OffsetTables, deps_compat=false)
-        # Aqua.test_deps_compat(OffsetTables, check_extras=false)
+        Aqua.test_all(OffsetTables, deps_compat=false)
+        Aqua.test_deps_compat(OffsetTables, check_extras=false)
     end
 
     @testset "Basic" begin
@@ -134,6 +134,6 @@ using RegressionTests
     end
 
     @testset "RegressionTests" begin
-        # RegressionTests.test(skip_unsupported_platforms=true)
+        RegressionTests.test(skip_unsupported_platforms=true)
     end
 end


### PR DESCRIPTION
Fixes 
```julia
@test rand(OffsetTable([typemax(Int)-10, 5, 5, 5])) == 1
```

Gets higher precision (no more than 1/2^64 probability error on any cell)

```julia
p = <arbitrary>
ot = OffsetTable(p)
@test maximum(abs, OffsetTables.probabilities(ot) ./ (big(typemax(UInt))+1) .- p ./ sum(big, p)) ≤ .5^64
```

Different, mostly better, perf:

```julia
julia> @b rand(1000) OffsetTables.OffsetTable(_) seconds=1
9.445 μs (5 allocs: 23.906 KiB) -> 9.500 μs (5 allocs: 23.906 KiB)

julia> @b rand(1:1000, 1000) OffsetTables.OffsetTable(_) seconds=1
9.445 μs (5 allocs: 23.906 KiB) -> 7.198 μs (5 allocs: 23.906 KiB)

julia> @b OffsetTables.probabilities(OffsetTable(rand(1:1000, 1000))) OffsetTable(_, normalize=false) seconds=1
2.538 μs (2 allocs: 16.031 KiB) -> 2.409 μs (2 allocs: 16.031 KiB)
```