### PR TITLE
Support old Julia versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.0'
+          - '1.6'
+          - '1'
           - '1.11.0-alpha2'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Random = "1.11"
-julia = "1.11"
+Random = "<0.0.1, 1"
+julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,6 @@ using RegressionTests
     end
 
     @testset "RegressionTests" begin
-        RegressionTests.test(skip_unsupported_platforms=true)
+        v"1.11.0-alpha2" <= VERSION && RegressionTests.test(skip_unsupported_platforms=true)
     end
 end


### PR DESCRIPTION
No perf difference detected locally from removing the `@inline`.