### PR TITLE
Skip RegressionTests locally

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,6 @@ using RegressionTests
     end
 
     @testset "RegressionTests" begin
-        RegressionTests.test(skip_unsupported_platforms=true)
+        "CI" ∈ keys(ENV) && RegressionTests.test(skip_unsupported_platforms=true)
     end
 end


### PR DESCRIPTION
Needed because RegressionTests is way slower than the rest of the tests. Workaround for https://github.com/LilithHafner/RegressionTests.jl/issues/50, folks can run `]bench` locally for benchmarks.