### PR TITLE
factor out throw on negative and make it robust to negatives occurring after two nonzeros when prenormalized

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -100,6 +100,11 @@ function _constant_alias_table(::Type{T}, ::Type{I}, index, length) where {I, T}
     _AliasTable(probability_alias, length)
 end
 
+function throw_on_negatives(weights)
+    for w in weights
+        w < 0 && throw(ArgumentError("found negative weight $w"))
+    end
+end
 function get_only_nonzero(weights)
     only_nonzero = -1
     for (i, w) in enumerate(weights)
@@ -110,8 +115,6 @@ function get_only_nonzero(weights)
                 only_nonzero = -2
                 break
             end
-        elseif w < 0
-            throw(ArgumentError("found negative weight $w at index $i"))
         end
     end
     only_nonzero == -1 && throw(ArgumentError("all weights are zero"))
@@ -130,6 +133,7 @@ hot_take(xs::Array, n) = HotTake(xs, n)
 hot_take(xs, n) = Iterators.take(xs, n)
 
 function _alias_table(::Type{T}, ::Type{I}, weights0) where {I, T}
+    throw_on_negatives(weights0)
     onz = get_only_nonzero(weights0)
     onz == -2 || return _constant_alias_table(T, I, onz, length(weights0))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ using Random, OffsetArrays
     @testset "Invalid weight error messages" begin
         @test_throws ArgumentError("found negative weight -1") AliasTable([1, -1])
         @test_throws ArgumentError("found negative weight -1") AliasTable([1, 1, -1])
+        @test_throws ArgumentError("found negative weight -1") AliasTable([3, typemax(Int), -1, typemax(Int)], normalize=false)
         @test_throws ArgumentError("all weights are zero") AliasTable([0, 0])
         @test_throws ArgumentError("all weights are zero") AliasTable([0])
         @test_throws ArgumentError("all weights are zero") AliasTable(UInt[0, 0])


### PR DESCRIPTION
The negative check on the float branch is unnecessary because that floored division can't introduce negatives.

The negative check in the _alias_table branch was broken (it short circuited if there were two positives before the first negative) causing this to happen

```julia
julia> AliasTable([3,typemax(Int),-1,typemax(Int)], normalize=false)
AliasTable([0x0000000000000003, 0x7fffffffffffffff, 0xffffffffffffffff, 0x7fffffffffffffff])
```