### PR TITLE
Avoid floating point overflow during construction by widening

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -417,10 +417,11 @@ end
 #     (frac_div(T(x), sm) + (i <= bonus) for (i,x) in enumerate(weights))
 # end
 
+widen_float(T, x) = typemax(T) < floatmax(x) ? x : widen_float(T, widen(x))
 function normalize_to_uint_frac_div(::Type{T}, v, sm) where {T <: Unsigned}
     if sm isa AbstractFloat
         shift = 8sizeof(T)-exponent(sm + sqrt(eps(sm)))-1
-        v2 = res = [floor(T, ldexp(x, shift)) for x in v]
+        v2 = res = [floor(T, ldexp(widen_float(T, x), shift)) for x in v]
         onz = get_only_nonzero(v2)
         onz != -2 && return res
         sm2 = sum(res)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,8 @@ using Random, OffsetArrays
               AliasTable{UInt8}([0x81, 0x81]) ==
               AliasTable([1,1]) ==
               AliasTable{UInt8}(UInt128[typemax(UInt64), typemax(UInt64)] .<< 5) ==
-              AliasTable{UInt8}([typemax(UInt32), typemax(UInt32)])
+              AliasTable{UInt8}([typemax(UInt32), typemax(UInt32)]) ==
+              AliasTable(Float16[1, 1])
         @test rand(AliasTable{UInt8}(fill(0x80, 2^18))) in 1:2^18
     end
 


### PR DESCRIPTION
Fixes

```julia
julia> AliasTable(Float16[1,1])
ERROR: InexactError: UInt64(Inf16)
```

The general approach unnecessarily widens `Float32` to `Float64` when constructing an `AliasTable{UInt128}` in exchange for handling abstract floats better (I hope).