### PR TITLE
Simplify and optimize constant alias tables

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -93,14 +93,10 @@ function AliasTable{T, I}(weights; _normalize=true) where {T <: Unsigned, I <: I
 end
 
 function _constant_alias_table(::Type{T}, ::Type{I}, index, length) where {I, T}
-    bitshift = top_set_bit(index - 1)
-    len = 1 << bitshift
-    points_per_cell = one(T) << (8*sizeof(T) - bitshift) # typemax(T)+1 / len
-
-    probability_alias = Memory{Tuple{T, I}}(undef, len)
-    for i in 1:len
-        probability_alias[i] = (points_per_cell, index-i)
-    end
+    points_per_cell = one(T) << (8*sizeof(T) - 1) # typemax(T)+1 / 2
+    probability_alias = Memory{Tuple{T, I}}(undef, 2)
+    probability_alias[1] = (points_per_cell, index-1)
+    probability_alias[2] = (points_per_cell, index-2)
     _AliasTable(probability_alias, length)
 end
 


### PR DESCRIPTION
Adopt the technique from lookup tables to the constant table case: out of bounds aliases. This allows storing a constant alias table in only two cells. (must be 2, because one cell can redirect at most typemax(T) points, so a single cell cannot redirect all its points)

This is a minor space regression for the one-weight alias table which is now stored in two cells instead of one.

The primary reason for implementing this PR is the minor code simplification. Ideally we would merge _lookup_alias_table and _constant_alias_table. 

Before
```julia
julia> @b vcat(fill(0, 100), 1) AliasTable
120.833 ns (2 allocs: 2.031 KiB)

julia> @b AliasTable(vcat(fill(0, 10_000), 1)) rand seconds=.5
2.859 ns

julia> Base.summarysize(AliasTable(vcat(fill(0, 100), 1)))
2088
```
After
```julia
julia> @b vcat(fill(0, 100), 1) AliasTable
42.731 ns (1 allocs: 64 bytes)

julia> @b AliasTable(vcat(fill(0, 10_000), 1)) rand seconds=.5
2.566 ns

julia> Base.summarysize(AliasTable(vcat(fill(0, 100), 1)))
72
