### PR TITLE
Add `set_weights!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,19 @@ julia> rand(at, 10)
 julia> using Chairmarks
 
 julia> @b at rand
-2.990 ns
+2.898 ns
 
 julia> @b rand(UInt)
-2.734 ns
+2.738 ns
 
 julia> @b rand(1000) AliasTable
-8.323 μs (5 allocs: 23.906 KiB)
+9.167 μs (2 allocs: 16.031 KiB)
 
 julia> @b AliasTable(rand(1000)) rand(_, 1000)
-1.420 μs (3 allocs: 7.875 KiB)
+1.506 μs (3 allocs: 7.875 KiB)
+
+julia> @b AliasTable(rand(1000)), rand(1000) AliasTables.set_weights!(_...)
+8.427 μs
 
 julia> using StatsBase
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,6 +17,9 @@ of probabilities. For example, to create a table with a 30% chance of returning 
 `probabilities` must be an abstract vector of real numbers. The sum need not be 1 as the
 input will be automatically normalized.
 
+See [`AliasTables.set_weights!`](@ref) for a way to change the weights of an existing alias
+table without GC-managed allocations.
+
 ## Sampling from an AliasTable
 
 Sample from an `AliasTable` the same way you would sample from any sampleable object using
@@ -155,5 +158,6 @@ domain according to the specifications layed out by the Random stdlib.
 AliasTable
 AliasTables.sample
 AliasTables.probabilities
+AliasTables.set_weights!
 length(::AliasTable)
 ```

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -454,16 +454,7 @@ function probabilities(at::AliasTable{T}) where T
         # For intertype hasing and equality purposes we sometimes store prob = 0.5
         # even when that is above points_per_cell. Bound here:
         prob2 = min(prob, points_per_cell)
-
-        # try
-            probs[i + alias] += prob2
-        # catch
-        #     @show at
-        #     @show at.probability_alias
-        #     @show i
-        #     # throw(KeyboardInterrupt())
-        #     retrhow()
-        # end
+        probs[i + alias] += prob2
         keep = points_per_cell - prob2
         iszero(keep) || (probs[i] += keep)
         # When len > typemax(T)+1, the excess elements exist only for intertype

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -118,7 +118,7 @@ struct AliasTable{T <: Unsigned, I <: Integer}
     If callers fail to do this, then equality and hashing may be broken.
     """
     function _AliasTable(probability_alias::Memory{Tuple{T, I}}, len) where {T, I}
-        shift = 8sizeof(T) - top_set_bit(length(probability_alias)) + 1
+        shift = max(8sizeof(T) - top_set_bit(length(probability_alias)) + 1, 0)
         mask = (one(T) << shift) - one(T)
         new{T, I}(mask, probability_alias, len)
     end
@@ -129,48 +129,55 @@ AliasTable(weights::AbstractVector{<:Real}; _normalize=true) = AliasTable{UInt64
 AliasTable{T}(weights::AbstractVector{<:Real}; _normalize=true) where T <: Unsigned = AliasTable{T, Int}(weights; _normalize=_normalize)
 function AliasTable{T, I}(weights; _normalize=true) where {T <: Unsigned, I <: Integer}
     require_one_based_indexing(weights)
+    len = 1 << top_set_bit(length(weights) - 1) # next_or_eq_power_of_two(length(weights))
+    probability_alias = Memory{Tuple{T, I}}(undef, len)
     if _normalize
         (is_constant, sm) = checked_sum(weights)
         if is_constant
-            _constant_alias_table(T, I, sm, length(weights))
+            _constant_alias_table!(probability_alias, sm, length(weights))
         elseif sm-true == typemax(T) # pre-normalized
-            _alias_table(T, I, weights)
+            _alias_table!(probability_alias, weights)
         else
             norm = malloc(T, length(weights))
             try
                 normalize_to_uint!(norm, weights, sm)
-                _alias_table(T, I, norm)
+                _alias_table!(probability_alias, norm)
             finally
                 free(norm)
             end
         end
     else
-        _alias_table(T, I, weights)
+        _alias_table!(probability_alias, weights)
     end
 end
 
-function _constant_alias_table(::Type{T}, ::Type{I}, index, length) where {I, T}
-    points_per_cell = one(T) << (8*sizeof(T) - 1) # typemax(T)+1 / 2
-    probability_alias = Memory{Tuple{T, I}}(undef, 2)
-    probability_alias[1] = (points_per_cell, index-1)
-    probability_alias[2] = (points_per_cell, index-2)
+function _constant_alias_table!(probability_alias::Memory{Tuple{T, I}}, index, length) where {T, I}
+    amount_redirected = one(T) << (8*sizeof(T) - 1) # typemax(T)+1 / 2, typically more than points per cell!
+    for i in eachindex(probability_alias)
+        probability_alias[i] = (amount_redirected, index-i)
+    end
     _AliasTable(probability_alias, length)
 end
 
-function _lookup_alias_table(::Type{T}, ::Type{I}, weights, mtz) where {I, T}
+function _lookup_alias_table!(probability_alias::Memory{Tuple{T, I}}, weights, mtz) where {T, I}
+    amount_redirected = one(T) << (8*sizeof(T) - 1) # typemax(T)+1 / 2, typically more than points per cell!
     len = 1 << (8sizeof(T) - mtz)
     len == 0 && throw(ArgumentError("Lookup table longer than typemax(Int)"))
-    probability_alias = Memory{Tuple{T, I}}(undef, len)
+    len > length(probability_alias) && throw(ArgumentError("Lookup table longer than length(probablity_alias)"))
     j = 1
     for (i, w) in enumerate(weights)
         j2 = j + Int(w >> mtz)
         j2-1 > len && throw(ArgumentError("sum(weights) is too high"))
         for k in j:j2-1
-            probability_alias[k] = (one(T) << mtz, i-k)
+            probability_alias[k] = (amount_redirected, i-k)
         end
         j = j2
     end
     j <= len && throw(ArgumentError("sum(weights) is too low"))
+    for j in len+1:length(probability_alias)
+        (p,a) = probability_alias[j-len]
+        probability_alias[j] = p, a-len
+    end
     _AliasTable(probability_alias, length(weights))
 end
 
@@ -208,25 +215,14 @@ function get_only_nonzero(weights)
     only_nonzero
 end
 
-"Like Iterators.Take, but faster"
-struct HotTake{T<:Array}
-    xs::T
-    n::Int
-    HotTake(xs::Array, n::Int) = new{typeof(xs)}(xs, min(n, length(xs)))
-end
-Base.iterate(A::HotTake, i=1) = ((i - 1)%UInt < A.n%UInt ? (@inbounds A.xs[i], i + 1) : nothing)
-Base.length(A::HotTake) = A.n
-hot_take(xs::Array, n) = HotTake(xs, n)
-hot_take(xs, n) = Iterators.take(xs, n)
+function _alias_table!(probability_alias::Memory{Tuple{T, I}}, weights) where {T, I}
+    throw_on_negatives(weights)
+    onz = get_only_nonzero(weights)
+    onz == -2 || return _constant_alias_table!(probability_alias, onz, length(weights))
 
-function _alias_table(::Type{T}, ::Type{I}, weights0) where {I, T}
-    throw_on_negatives(weights0)
-    onz = get_only_nonzero(weights0)
-    onz == -2 || return _constant_alias_table(T, I, onz, length(weights0))
-
-    weights = hot_take(weights0, findlast(!iszero, weights0))
     bitshift = top_set_bit(length(weights) - 1)
     len = 1 << bitshift # next_or_eq_power_of_two(length(weights))
+    @assert len == length(probability_alias)
     points_per_cell = one(T) << (8*sizeof(T) - bitshift) # typemax(T)+1 / len
 
     # The reason this optimiation exists is to prevent when points_per_cell == 0.
@@ -235,9 +231,7 @@ function _alias_table(::Type{T}, ::Type{I}, weights0) where {I, T}
     # weights. This is important for equality and hashing.
     mtz = minimum_trailing_zeros(weights)
     lookup_table_bits = 8sizeof(T) - mtz
-    lookup_table_bits < bitshift && return _lookup_alias_table(T, I, weights, mtz)
-
-    probability_alias = Memory{Tuple{T, I}}(undef, len)
+    lookup_table_bits < bitshift && return _lookup_alias_table!(probability_alias, weights, mtz)
 
     # @show sum(weights)
     # @show weights
@@ -323,7 +317,7 @@ function _alias_table(::Type{T}, ::Type{I}, weights0) where {I, T}
         points_per_cell == thirsty_desired && (probability_alias[thirsty_i] = (0, 0)) # loosely thirsty, but satisfied. Zero out the undef.
     end
 
-    _AliasTable(probability_alias, length(weights0))
+    _AliasTable(probability_alias, length(weights))
 end
 
 """
@@ -426,12 +420,29 @@ julia> AliasTables.probabilities(AliasTable([0, 1, 0]))
 """
 function probabilities(at::AliasTable{T}) where T
     bitshift = top_set_bit(length(at.probability_alias) - 1)
-    points_per_cell = one(T) << (8*sizeof(T) - bitshift)#typemax(T)+1 / len
+    # points_per_cell = typemax(T)+1 / len, but at least 1, for
+    # cases where len > typemax(T)+1
+    points_per_cell = one(T) << max(0, 8*sizeof(T) - bitshift)
     probs = zeros(T, at.length)
     for (i, (prob, alias)) in enumerate(at.probability_alias)
-        probs[i + alias] += prob
-        keep = points_per_cell - prob
+        # For intertype hasing and equality purposes we sometimes store prob = 0.5
+        # even when that is above points_per_cell. Bound here:
+        prob2 = min(prob, points_per_cell)
+
+        # try
+            probs[i + alias] += prob2
+        # catch
+        #     @show at
+        #     @show at.probability_alias
+        #     @show i
+        #     # throw(KeyboardInterrupt())
+        #     retrhow()
+        # end
+        keep = points_per_cell - prob2
         iszero(keep) || (probs[i] += keep)
+        # When len > typemax(T)+1, the excess elements exist only for intertype
+        # hashing and equality purposes and should be ignored.
+        i > typemax(T) && break
     end
     if all(iszero, probs)
         probs[sample(zero(T), at)] = typemax(T)

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -333,7 +333,7 @@ as well.
 See also [`AliasTable`](@ref), [`AliasTables.probabilities`](@ref)
 """
 function sample(x::T, at::AliasTable{T, I}) where {T, I}
-    shift = top_set_bit(typemax(T)) - top_set_bit(length(at.probability_alias)) + 1
+    shift = max(top_set_bit(typemax(T)) - top_set_bit(length(at.probability_alias)) + 1, 0)
     cell = (x >> shift) + 1
     # @assert (one(T) << shift) - one(T) == at.mask
     val = x & at.mask

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -84,7 +84,7 @@ The mapping can be accessed directly via
 [`AliasTables.sample(x::T, at::AliasTable{T, I})`](@ref AliasTables.sample)
 or indirectly via the `Random` API: `rand(at)`, `rand(rng, at)`, `rand(at, dims...)`, etc.
 
-See also [`AliasTables.set_weights`](@ref)
+See also [`AliasTables.set_weights!`](@ref)
 
 # Example
 

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -63,6 +63,7 @@ if isdefined(Base, :top_set_bit)
     const top_set_bit = Base.top_set_bit
 else
     top_set_bit(x::Integer) = 64 - leading_zeros(UInt64(x)) # VERSION <= 1.9
+    top_set_bit(x::Int) = 64 - leading_zeros(x)
 end
 
 if isdefined(Base, :require_one_based_indexing) # VERSION == 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,16 @@ using Random, OffsetArrays, StableRNGs
             @test counts(Iterators.map(x -> AliasTables.sample(x, at), typemin(UInt16):typemax(UInt16)), 3) ==
                 2^16/16 * [10, 5, 1]
         end
+        @testset "Sampling when therer are more than typemax(T) weights" begin
+            let at = AliasTable{UInt8}(vcat([1, 1], fill(0, 2^8)))
+                @test counts(Iterators.map(x -> AliasTables.sample(x, at), 0x00:0xff), 258) ==
+                    vcat([128, 128], zeros(2^8))
+            end
+            let at = AliasTable{UInt8}(vcat([1], fill(0, 2^8)))
+                @test counts(Iterators.map(x -> AliasTables.sample(x, at), 0x00:0xff), 257) ==
+                    vcat(256, zeros(2^8))
+            end
+        end
     end
 
     @testset "Equality and hashing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,7 +110,7 @@ using Random, OffsetArrays, StableRNGs
         a = AliasTable([1, 2, 3])
         b = AliasTable([1, 2, 3, 0, 0])
         @test a != b
-        @test a.probability_alias == b.probability_alias
+        @test a.probability_alias != b.probability_alias
 
         data = [
             [
@@ -195,7 +195,8 @@ using Random, OffsetArrays, StableRNGs
     end
 
     @testset "Misc" begin
-        AliasTables._alias_table(UInt8, Int, (0x01, 0xff)) == AliasTable([1,255])
+        probability_alias = AliasTables.Memory{Tuple{UInt8, Int}}(undef, 2)
+        AliasTables._alias_table!(probability_alias, (0x01, 0xff)) == AliasTable([1,255])
     end
 
     @testset "RegressionTests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,14 @@ using Random, OffsetArrays, StableRNGs
         @test !Base.hasmethod(AliasTables.sample, Tuple{UInt32, AliasTable{UInt64, Int}})
     end
 
+    @testset "set_weights!" begin
+        at = AliasTable([1, 2, 3, 0, 0, 0])
+        at2 = AliasTable([1, 2, 3, 4, 5, 6])
+        @test at === AliasTables.set_weights!(at, [1, 2, 3, 4, 5, 6])
+        @test at == at2
+        @test at !== at2
+    end
+
     @testset "Exact" begin
         for i in 1:100
             p = rand(i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,7 +104,7 @@ using Random, OffsetArrays, StableRNGs
             @test counts(Iterators.map(x -> AliasTables.sample(x, at), typemin(UInt16):typemax(UInt16)), 3) ==
                 2^16/16 * [10, 5, 1]
         end
-        @testset "Sampling when therer are more than typemax(T) weights" begin
+        @testset "Sampling when there are more than typemax(T) weights" begin
             let at = AliasTable{UInt8}(vcat([1, 1], fill(0, 2^8)))
                 @test counts(Iterators.map(x -> AliasTables.sample(x, at), 0x00:0xff), 258) ==
                     vcat([128, 128], zeros(2^8))


### PR DESCRIPTION
- Always same length probability_offset (to support mutation). This disables several special case optimizations for when weights is sparse.
- add `set_weights!`
- add docs
- add tests
