### PR TITLE
Remove redundant `throw_on_negatives` in common path

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -176,6 +176,7 @@ function set_weights!(at::AliasTable{T}, weights::AbstractVector{<:Real}; _norma
             end
         end
     else
+        throw_on_negatives(weights)
         _alias_table!(probability_alias, weights)
     end
     at
@@ -244,7 +245,6 @@ function get_only_nonzero(weights)
 end
 
 function _alias_table!(probability_alias::Memory{Tuple{T, I}}, weights) where {T, I}
-    throw_on_negatives(weights)
     onz = get_only_nonzero(weights)
     onz == -2 || return _constant_alias_table!(probability_alias, onz, length(weights))
 


### PR DESCRIPTION
This is safe bc `checked_sum` checks for negatives and `normalize_to_uint!` cannot introduce negatives.