### PR TITLE
Release 1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AliasTables"
 uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
New feature: [`set_weights!`](https://aliastables.lilithhafner.com/dev/#AliasTables.set_weights!)

Slight microbenchmark performance changes

```julia

julia> @b rand(1000) AliasTable seconds=1
9.083 μs (5 allocs: 23.906 KiB) => 9.125 μs (2 allocs: 16.031 KiB)

julia> @b rand(1_000_000) AliasTable seconds=1
12.888 ms (5 allocs: 23.629 MiB) => 13.423 ms (2 allocs: 16.000 MiB, 0.51% gc time)

julia> @b rand(100_000_000) AliasTable seconds=10
1.740 s (5 allocs: 2.745 GiB, 13.36% gc time) => 1.372 s (2 allocs: 2.000 GiB, 0.01% gc time)

julia> @b AliasTable(rand(1000)) _ rand(_, 1000) _ seconds=1
1.488 μs (3 allocs: 7.875 KiB) => 1.487 μs (3 allocs: 7.875 KiB)

julia> @b AliasTable(rand(1_000_000)) _ rand(_, 1000) _ seconds=1
2.701 μs (3 allocs: 7.875 KiB) => 2.548 μs (3 allocs: 7.875 KiB)

julia> @b AliasTable(rand(100_000_000)) _ rand(_, 1000) _ seconds=10
7.917 μs (3 allocs: 7.875 KiB) => 7.833 μs (3 allocs: 7.875 KiB)
```

More lines in every category with largest growth in comments.
|                | v1.0.0 | v1.1.0 |
|----------------|--------|--------|
| source code    | 292    | 351    |
| source comment | 127    | 192    |
| source blank   | 76     | 103    |
| test code      | 172    | 208    |
| test comment   | 6      | 6      |
| test blank     | 18     | 20     |

Macrobenchmarks: it's possible to have substantially fewer allocations, but on my system this does not result in increased perforamance

```julia
julia> function f(iterations, weights, samples)
           x = rand(weights)
           y = rand(Int, samples)
           h = UInt(0)
           for _ in 1:iterations
               at = AliasTable(rand!(x))
               h = hash(rand!(y, at))
           end
           h
       end

julia> @b f(10_000, 1_000, 1_000) seconds=10
204.462 ms (70006 allocs: 233.933 MiB, 1.79% gc time) => 199.634 ms (20006 allocs: 156.571 MiB, 1.08% gc time)

julia> @b f(100, 100_000, 1_000) seconds=10
166.474 ms (706 allocs: 277.078 MiB, 1.77% gc time) => 169.883 ms (206 allocs: 200.774 MiB, 0.92% gc time)

julia> @b f(10, 10_000_000, 1_000) seconds=10
1.790 s (76 allocs: 3.320 GiB, 4.23% gc time) => 1.959 s (26 allocs: 2.575 GiB, 1.15% gc time)

julia> function g(iterations, weights, samples)
           x = rand(weights)
           y = rand(Int, samples)
           at = AliasTable(x)
           h = UInt(0)
           for _ in 1:iterations
               at = AliasTables.set_weights!(at, rand!(x))
               h = hash(rand!(y, at))
           end
           h
       end

julia> @b g(10_000, 1_000, 1_000) seconds=10
196.480 ms (8 allocs: 31.781 KiB)

julia> @b g(100, 100_000, 1_000) seconds=10
168.683 ms (8 allocs: 2.771 MiB)

julia> @b g(10, 10_000_000, 1_000) seconds=10
1.950 s (8 allocs: 332.302 MiB, 0.15% gc time)
```

A couple of obscure bugfixes:

```julia
rand(AliasTable{UInt8}(vcat(fill(0, 500), 1))) == 501
AliasTable{UInt8}(vcat(fill(0x00, 2^8), 0x80, 0x80)) # (Issue #34)
```