### PR TITLE
Fix overflow on shifting T2.(v) .<< sizeof(T)

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -625,7 +625,7 @@ function normalize_to_uint!(res::AbstractVector{T}, v, sm) where {T <: Unsigned}
 
     sm3 = zero(T)
 
-    T2 = promote_type(widen(T), typeof(sm2))
+    T2 = widen(promote_type(T, typeof(sm2)))
     for (i,x) in enumerate(v2)
         # @assert x < sm2
         # @assert sm2 != 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,9 @@ using Random, OffsetArrays, StableRNGs
               AliasTable([1,1]) ==
               AliasTable{UInt8}(UInt128[typemax(UInt64), typemax(UInt64)] .<< 5) ==
               AliasTable{UInt8}([typemax(UInt32), typemax(UInt32)]) ==
-              AliasTable(Float16[1, 1])
+              AliasTable(Float16[1, 1]) ==
+              AliasTable{UInt8}([0x0ffffffffffffffff000000000000000, 0x0ffffffffffffffff000000000000000]) == # Issue #44
+              AliasTable([0x0ffffffffffffffff000000000000000, 0x0ffffffffffffffff000000000000000])
         @test rand(AliasTable{UInt8}(fill(0x80, 2^18))) in 1:2^18
         @test AliasTable{UInt8}(vcat(fill(0x00, 2^8), 0x80, 0x80)) == # Issue #34
                      AliasTable(vcat(fill(0x00, 2^8), 0x80, 0x80))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,8 @@ using Random, OffsetArrays, StableRNGs
               AliasTable{UInt8}([typemax(UInt32), typemax(UInt32)]) ==
               AliasTable(Float16[1, 1]) ==
               AliasTable{UInt8}([0x0ffffffffffffffff000000000000000, 0x0ffffffffffffffff000000000000000]) == # Issue #44
-              AliasTable([0x0ffffffffffffffff000000000000000, 0x0ffffffffffffffff000000000000000])
+              AliasTable([0x0ffffffffffffffff000000000000000, 0x0ffffffffffffffff000000000000000]) ==
+              AliasTable{UInt32}([0x0000fffffff00000, 0x0000fffffff00000])
         @test rand(AliasTable{UInt8}(fill(0x80, 2^18))) in 1:2^18
         @test AliasTable{UInt8}(vcat(fill(0x00, 2^8), 0x80, 0x80)) == # Issue #34
                      AliasTable(vcat(fill(0x00, 2^8), 0x80, 0x80))


### PR DESCRIPTION
Only happens when eltype(v) is bigger than T and some elements are within sizeof(T) bytes of filling their whole type.

fixes #44