### PR TITLE
Round small floating point values up instead of down

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -612,11 +612,10 @@ function normalize_to_uint!(res::AbstractVector{T}, v, sm) where {T <: Unsigned}
     if sm isa AbstractFloat
         shift = 8sizeof(T)-exponent(sm + sqrt(eps(sm)))-1
         for i in eachindex(res, v)
-            res[i] = floor(T, ldexp(widen_float(T, v[i]), shift))
+            # Rounding up could cause sm2 to overflow in AliasTable(vcat(1.0-sqrt(eps(1.0)), fill(1e-100, 2^38))
+            res[i] = ceil(T, ldexp(widen_float(T, v[i]), shift))
         end
         v2 = res
-        onz = get_only_nonzero(v2)
-        onz != -2 && return res
         sm2 = sum(res)
     else
         v2 = v

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,8 @@ using Random, OffsetArrays, StableRNGs
                      AliasTable(vcat(fill(0x00, 2^8), 0x80, 0x80))
         @test length(AliasTable([1, 2, 3])) == 3
         @test rand(AliasTable{UInt8}(vcat(fill(0, 500), 1))) == 501 # PR #36
+        @test AliasTable{UInt8}(fill(1, 1000)) == AliasTable{UInt8}(fill(1.0, 1000)) # Issue #43
+        @test AliasTables.probabilities(AliasTable{UInt8}(vcat(4.0, fill(1.0, 1000))))[1] ∈ 1:2
     end
 
     @testset "Invalid weight error messages" begin
@@ -152,10 +154,14 @@ using Random, OffsetArrays, StableRNGs
                 AliasTable([1, 2.0001, 5]),
             ],[
                 AliasTable([0,0,0,0,1]),
+            ],[
                 AliasTable([1e-70,0,0,0,1]),
+                AliasTable([2,0,0,0,typemax(UInt)-1]),
             ],[
                 AliasTable([0,0,0,0,1,0,0,0,0,0,0,0]),
+            ],[
                 AliasTable([1e-70,0,0,0,1,0,0,0,0,0,0,1e-70]),
+                AliasTable([2,1,0,0,typemax(UInt)-3,0,0,0,0,0,0,1]),
             ],[
                 AliasTable([1, 2, 3, 5]),
                 AliasTable{UInt64, Int8}([1, 2, 3, 5]),


### PR DESCRIPTION
1e-20 is pretty hard to differentiate from 5.4e-20 (2^-64), but much easier to differentiate from 0. In general, rounding up is better logarithmicly.

However, the real reason for this change is to fix #43 which is due to rounding down introducing new zeros. This avoids that. The `get_only_nonzero` check was a poor substitute because if all nonzeros round to zero, it throws.

The equality test changes (specifically that `[1e-70, 0, 0, 1, 0, 0, 1e-70]` is now `[2, 1, 0, typemax(UInt)-3, 0, 0, 1]`) look like regressions, and they are, a bit, but the introduction of nonzeros is nothing new. Try `AliasTable(vcat(0, rand(10)))`.