### PR TITLE
Release 1.1.1!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AliasTables"
 uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
A bugfix release! Many obscure bugfixes (the most severe of which is that AliasTables 1.1.0 on Julia 1.8 and below was totally broken on 32-bit systems)


More lines of tests, but not much significant change elsewhere. A wee bit of src churn, but not much.

|                | v1.0.0 | v1.1.0 | v1.1.1 |
|----------------|--------|--------|--------|
| source code    | 292    | 351    | 351    |
| source comment | 127    | 192    | 193    |
| source blank   | 76     | 103    | 103    |
| test code      | 172    | 208    | 225    |
| test comment   | 6      | 6      | 7      |
| test blank     | 18     | 20     | 20     |

No significant microbenchmark changes

```julia
julia> @b rand(1000) AliasTable seconds=1
12.583 μs (2 allocs: 16.031 KiB) => 12.709 μs (2 allocs: 16.031 KiB)

julia> @b rand(1_000_000) AliasTable seconds=1
13.657 ms (2 allocs: 16.000 MiB) => 14.708 ms (2 allocs: 16.000 MiB)

julia> @b rand(10_000_000) AliasTable seconds=3
155.561 ms (2 allocs: 256.000 MiB, 0.07% gc time) => 149.142 ms (2 allocs: 256.000 MiB, 0.08% gc time)

julia> @b AliasTable(rand(1000)) _ rand(_, 1000) _ seconds=1
1.538 μs (3 allocs: 7.875 KiB) => 1.571 μs (3 allocs: 7.875 KiB)

julia> @b AliasTable(rand(1_000_000)) _ rand(_, 1000) _ seconds=1
2.941 μs (3 allocs: 7.875 KiB) => 3.012 μs (3 allocs: 7.875 KiB)

julia> @b AliasTable(rand(10_000_000)) _ rand(_, 1000) _ seconds=3
7.889 μs (3 allocs: 7.875 KiB) => 7.917 μs (3 allocs: 7.875 KiB)
```