### PR TITLE
Use underlying RNG's SIMD (if Xoshiro)

### DIFF
--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -358,7 +358,7 @@ function _sample!(xs::AbstractArray{I}, at::AliasTable{T, I}) where {T<:Base.Bit
     shift = max(top_set_bit(typemax(T)) - top_set_bit(length(at.probability_alias)) + 1, 0)
     # @assert (one(T) << shift) - one(T) == at.mask
     @simd ivdep for i in eachindex(xs)
-        x = xs[i]%T
+        x = unsigned(xs[i])
         cell = (x >> shift) + 1
         val = x & at.mask
         prob, alias = @inbounds at.probability_alias[cell%Int] # see proof below
@@ -370,7 +370,7 @@ end
 function Random.rand!(rng::Union{Random.TaskLocalRNG, Random.XoshiroSimd.Xoshiro},
                       dst::Array{I},
                       st::Random.SamplerTrivial{AliasTable{T, I}, I}) where {T<:Base.BitUnsigned, I<:Base.BitInteger}
-    if sizeof(I) <= sizeof(T)
+    if sizeof(I) == sizeof(T)
         rand!(rng, dst)
         _sample!(dst, st.self)
     else

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -367,7 +367,7 @@ function _sample!(xs::AbstractArray{I}, at::AliasTable{T, I}) where {T<:Base.Bit
     xs
 end
 
-function Random.rand!(rng::Union{Random.TaskLocalRNG, Random.XoshiroSimd.Xoshiro},
+function Random.rand!(rng::Random.AbstractRNG,
                       dst::Array{I},
                       st::Random.SamplerTrivial{AliasTable{T, I}, I}) where {T<:Base.BitUnsigned, I<:Base.BitInteger}
     if sizeof(I) == sizeof(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,6 +128,16 @@ using Random, OffsetArrays, StableRNGs
         end
     end
 
+    @testset "Bulk generation" begin
+        for T in [UInt8, UInt64, UInt128], I in [Int8, Int64, Int128]
+            at = AliasTable{T, I}([1,10,100])
+            x = rand(at, 1000)
+            @test x isa Vector{I}
+            @test all(∈(1:3), x)
+            @test count(==(1), x) < count(==(2), x) < count(==(3), x)
+        end
+    end
+
     @testset "Equality and hashing" begin
         a = AliasTable([1, 2, 3])
         b = AliasTable([1, 2, 3, 0, 0])


### PR DESCRIPTION
A wee bit faster (sampling 10^6 times goes from 1.5ms to 1ms)

Also restrict the scope of `@inbounds`.