### PR TITLE
Delete MallocArrays and replace it with a dependency on PtrArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "AliasTables"
 uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
+PtrArrays = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+PtrArrays = "1.1.0"
 Random = "<0.0.1, 1"
 julia = "1"
 

--- a/src/AliasTables.jl
+++ b/src/AliasTables.jl
@@ -1,58 +1,6 @@
 module AliasTables
 
-using Random
-
-# TODO switch to depending on https://github.com/LilithHafner/MallocArrays.jl instead
-# of copying the souce code
-module MallocArrays
-
-export malloc, free, MallocArray
-
-struct MallocArray{T, N} <: AbstractArray{T, N}
-    ptr::Ptr{T}
-    size::NTuple{N, Int}
-end
-
-"""
-    malloc(T::Type, dims::Int...) -> MallocArray{T, N} <: AbstractArray{T, N}
-
-Allocate a new array of type `T` and dimensions `dims` using the C stdlib's `malloc`.
-
-`T` must be an `isbitstype`.
-
-This array is not tracked by Julia's garbage collector, so it is the user's responsibility
-to call [`free`](@ref) on it when it is no longer needed.
-"""
-function malloc(::Type{T}, dims::Int...) where T
-    isbitstype(T) || throw(ArgumentError("malloc only supports isbits types"))
-    MallocArray(Ptr{T}(Libc.malloc(sizeof(T) * prod(dims))), dims)
-end
-
-"""
-    free(m::MallocArray)
-
-Free the memory allocated by a MallocArray.
-
-See also [`malloc`](@ref).
-"""
-function free(m::MallocArray)
-    Libc.free(m.ptr)
-end
-
-Base.size(m::MallocArray) = m.size
-Base.IndexStyle(::Type{<:MallocArray}) = IndexLinear()
-Base.@propagate_inbounds function Base.getindex(m::MallocArray, i::Int)
-    @boundscheck checkbounds(m, i)
-    unsafe_load(m.ptr, i)
-end
-Base.@propagate_inbounds function Base.setindex!(m::MallocArray, v, i::Int)
-    @boundscheck checkbounds(m, i)
-    unsafe_store!(m.ptr, v, i)
-    m
-end
-
-end
-using .MallocArrays
+using Random, PtrArrays
 
 export AliasTable
 VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public sample, probabilities, set_weights!"))


### PR DESCRIPTION
Resolves 

```
# TODO switch to depending on https://github.com/LilithHafner/MallocArrays.jl instead
# of copying the souce code
```

NFC

Maybe increases precompile and load time, but should decrease both when used in conjunction with other packages that depend on PtrArrays.